### PR TITLE
Don't fix statsd version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Andy McKay',
     author_email='andym@mozilla.com',
     license='BSD',
-    install_requires=['statsd==2.1.2'],
+    install_requires=['statsd>=2.1.2'],
     packages=['django_statsd',
               'django_statsd/patches',
               'django_statsd/clients',


### PR DESCRIPTION
@YPlan we've been using `statsd==3.1` with `django-statsd-mozilla` for some time. We didn't realize `django-statsd-mozilla` fixes `statsd` at 2.1.2 in its `setup.py` until recently, when upgrading Django, the test suite under nose outputs: 

```
.../python2.7/site-packages/nose/plugins/manager.py:395: RuntimeWarning: Unable to load plugin django_statsd = django_statsd:NoseStatsd: (statsd 3.1 (/opt/yplan/venv/lib/python2.7/site-packages), Requirement.parse('statsd==2.1.2'))
  RuntimeWarning)
```

If there is no particular reason to be fixed at 2.1.2 then I suggest allowing 2.1.2+ :smile: As I've said, it's working for us.