### PR TITLE
make-middleware-compatible-with-django-1.10

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -5,9 +5,13 @@ from django.conf import settings
 from django.http import Http404
 
 from django_statsd.clients import statsd
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
 
-class GraphiteMiddleware(object):
+class GraphiteMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         statsd.incr('response.%s' % response.status_code)
@@ -22,7 +26,7 @@ class GraphiteMiddleware(object):
                 statsd.incr('response.auth.500')
 
 
-class GraphiteRequestTimingMiddleware(object):
+class GraphiteRequestTimingMiddleware(MiddlewareMixin):
     """statsd's timing data per view."""
 
     def process_view(self, request, view_func, view_args, view_kwargs):


### PR DESCRIPTION
Make middleware compatible with django 1.10