### PR TITLE
celery: Reinstate python2 support

### DIFF
--- a/django_statsd/celery.py
+++ b/django_statsd/celery.py
@@ -1,5 +1,4 @@
-
-
+from __future__ import absolute_import
 from django_statsd.clients import statsd
 import time
 


### PR DESCRIPTION
Commit dd33a4c66fd155fe87118b6807f08aefa35a69ca, among other things, removed a `from __future__ import absolute_import` from the celery module, with a commit message mentioning the 2to3 tool for automatic conversion from python2 to python3.

The specific change of removing absolute_import turns out to break python2 usage, (since it now refers to itself!), while keeping the absolute_import still works on python3 as well (where it doesn't do anything, since absolute_import is now the default).

The breakage is hidden by the fact that the from celery import signals is wrapped in a `try: ... except ImportError: ...` block. No celery metrics are sent to statsd, without any indication of error.

---
(Thanks for stepping up as a maintainer! :))