### PR TITLE
fix(middleware): check for request.user is None

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -25,15 +25,17 @@ class GraphiteMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         statsd.incr('response.%s' % response.status_code)
-        if hasattr(request, 'user') and is_authenticated(request.user):
-            statsd.incr('response.auth.%s' % response.status_code)
+        if getattr(request, 'user', None):
+            if is_authenticated(request.user):
+                statsd.incr('response.auth.%s' % response.status_code)
         return response
 
     def process_exception(self, request, exception):
         if not isinstance(exception, Http404):
             statsd.incr('response.500')
-            if hasattr(request, 'user') and is_authenticated(request.user):
-                statsd.incr('response.auth.500')
+            if getattr(request, 'user', None):
+                if is_authenticated(request.user):
+                    statsd.incr('response.auth.500')
 
 
 class GraphiteRequestTimingMiddleware(MiddlewareMixin):


### PR DESCRIPTION
The django test Client creates a request that has the user attribute that is None unless the Client has a logged in user. This causes the middleware to fail when running tests that use the Client.