### PR TITLE
Drop support for django < 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ python:
 sudo: false
 
 env:
-    - DJANGO=1.8
-    - DJANGO=1.9
-    - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
     - DJANGO=master
@@ -29,12 +26,6 @@ matrix:
         env: DJANGO=master
       - python: "3.4"
         env: DJANGO=2.0
-      - python: "3.6"
-        env: DJANGO=1.8
-      - python: "3.6"
-        env: DJANGO=1.9
-      - python: "3.6"
-        env: DJANGO=1.10
 
     allow_failures:
       - env: DJANGO=master

--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -4,35 +4,23 @@ import time
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.http import Http404
+from django.utils.deprecation import MiddlewareMixin
 
 from django_statsd.clients import statsd
-
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    class MiddlewareMixin(object):
-        pass
-
-
-def is_authenticated(user):
-    if DJANGO_VERSION < (1, 10):
-        return user.is_authenticated()
-    return user.is_authenticated
 
 
 class GraphiteMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         statsd.incr('response.%s' % response.status_code)
-        if hasattr(request, 'user') and is_authenticated(request.user):
+        if hasattr(request, 'user') and request.user.is_authenticated:
             statsd.incr('response.auth.%s' % response.status_code)
         return response
 
     def process_exception(self, request, exception):
         if not isinstance(exception, Http404):
             statsd.incr('response.500')
-            if hasattr(request, 'user') and is_authenticated(request.user):
+            if hasattr(request, 'user') and request.user.is_authenticated:
                 statsd.incr('response.auth.500')
 
 

--- a/django_statsd/patches/db.py
+++ b/django_statsd/patches/db.py
@@ -1,7 +1,4 @@
-try:
-    from django.db.backends import utils as util
-except ImportError:
-    from django.db.backends import util
+from django.db.backends import utils
 
 from django_statsd.patches.utils import wrap, patch_method
 from django_statsd.clients import statsd
@@ -35,6 +32,6 @@ def patch():
     The CursorWrapper is a pretty small wrapper around the cursor.  If
     you are NOT in debug mode, this is the wrapper that's used.
     """
-    patch_method(util.CursorWrapper, 'execute')(patched_execute)
-    patch_method(util.CursorWrapper, 'executemany')(patched_executemany)
-    patch_method(util.CursorWrapper, 'callproc')(patched_callproc)
+    patch_method(utils.CursorWrapper, 'execute')(patched_execute)
+    patch_method(utils.CursorWrapper, 'executemany')(patched_executemany)
+    patch_method(utils.CursorWrapper, 'callproc')(patched_callproc)

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,13 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       {py27,py33,py34,py35,pypy,pypy3}-django18,
-       {py27,py34,py35,pypy,pypy3}-django{19,110},
        {py27,py34,py35,py36,pypy,pypy3}-django111,
+       {py34,py35,py36,pypy,pypy3}-django20
        {py35,py36,pypy,pypy3}-djangomaster
 
 [travis:env]
 DJANGO =
-    1.8: django18
-    1.9: django19
-    1.10: django110
-    1.11: django111
+    2.0: django20
     master: djangomaster
 
 [testenv]
@@ -24,9 +20,7 @@ setenv =
 
 deps =
         py27: -roptional.txt
-        django18: Django>=1.8,<1.9
-        django19: Django>=1.9,<1.10
-        django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
+        django20: Django>=2.0,<2.1
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements.txt


### PR DESCRIPTION
According to Supported Versions in https://www.djangoproject.com/download/ all these versions reached their end of life.

The django maintainers suggested to drop support for Django < 1.11 in third party libraries with the release of Django 2.0 at December 2, 2017. See https://docs.djangoproject.com/en/2.0/releases/2.0/#third-party-library-support-for-older-version-of-django

Since there's no release of django-statsd with Django 2.0 support, I recommend publishing a new release before merging this.